### PR TITLE
rbenv-update fails without RBENV_ROOT

### DIFF
--- a/bin/rbenv-update
+++ b/bin/rbenv-update
@@ -15,7 +15,7 @@ rbenv_update() {
   echo
 }
 
-cd $RBENV_ROOT
+cd ${RBENV_ROOT:-$(rbenv root)}
 rbenv_update rbenv
 
 for plugin in plugins/*; do


### PR DESCRIPTION
- RBENV_ROOT is not set by any of the default rbenv configuration
  options, only the shared configuration. This means that rbenv-update
  does the same as 'cd ~' without this being set.
- rbenv-root provides the value that should be used here. To ensure
  existing functionality compatibility, I have made the use of
  rbenv-root conditional on the nonexistence of $RBENV_ROOT.
