### PR TITLE
Fixes "Your branch is ahead of ''origin/master' by 22 commits." style messages

### DIFF
--- a/bin/rbenv-update
+++ b/bin/rbenv-update
@@ -11,6 +11,7 @@ indent_output() {
 rbenv_update() {
   echo -e "\033[1;32mupdating $1\033[0m"
   git checkout master 2>&1 | indent_output
+  git fetch origin 2>&1 | indent_output
   git pull origin master 2>&1 | indent_output
   echo
 }


### PR DESCRIPTION
Calls git fetch origin before pull to avoid "Your branch is ahead of 'origin/master' by 22 commits." style messages
