### PR TITLE
Get updates from all remotes

### DIFF
--- a/bin/rbenv-update
+++ b/bin/rbenv-update
@@ -11,8 +11,10 @@ indent_output() {
 rbenv_update() {
   echo -e "\033[1;32mupdating $1\033[0m"
   git checkout master 2>&1 | indent_output
-  git fetch origin 2>&1 | indent_output
-  git pull origin master 2>&1 | indent_output
+  for remote in $(git remote); do
+    git fetch ${remote} 2>&1 | indent_output
+    git pull ${remote} master 2>&1 | indent_output
+  done
   echo
 }
 


### PR DESCRIPTION
Previously, update only worked against origin, so if you had a
fork of rbenv or any plugins, it would not get updates from upstream.
Now we cycle through all remotes, getting the updates from each
remotes master branch.