### PR TITLE
Guard against non-git repos

### DIFF
--- a/bin/rbenv-update
+++ b/bin/rbenv-update
@@ -28,7 +28,7 @@ cd ${RBENV_ROOT:-$(rbenv root)}
 rbenv_update rbenv
 
 for plugin in plugins/*; do
-  cd $plugin
+  pushd $plugin >/dev/null
   rbenv_update `basename $plugin`
-  cd - >/dev/null
+  popd >/dev/null
 done


### PR DESCRIPTION
This PR gets halfway to #6. It guards against a git-update if the directory
isn't a git repo. However, it doesn't (yet) do a homebrew upgrade.

Also contains two other changes:
pushd/popd instead of relying on `cd -`
does a proper git-repo check instead of assuming a .git directory means git repo
