### PR TITLE
Add a git clone line

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,7 @@ Simply clone the repository into the plugins directory:
 
     mkdir -p $RBENV_ROOT/plugins
     git clone https://github.com/rkh/rbenv-update.git $RBENV_ROOT/plugins/rbenv-update
+    
+Or use this line if rbenv is install in your home directory:
+
+    git clone https://github.com/rkh/rbenv-update.git ~/.rbenv/plugins/rbenv-update


### PR DESCRIPTION
A quick git checkout line for when rbenv is installed in ~/.rbenv which is quite common.