### PR TITLE
Quick start improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,5 +4,6 @@ This [rbenv](http://rbenv.org/) plugin adds the `rbenv update` command that upda
 
 Simply clone the repository into the plugins directory:
 
-    mkdir -p $RBENV_ROOT/plugins
-    git clone https://github.com/rkh/rbenv-update.git $RBENV_ROOT/plugins/rbenv-update
+    [ -z "$RBENV_ROOT" ] && export RBENV_ROOT="$HOME/.rbenv"
+    mkdir -p "$RBENV_ROOT/plugins"
+    git clone https://github.com/rkh/rbenv-update.git "$RBENV_ROOT/plugins/rbenv-update"


### PR DESCRIPTION
Two interrelated changes in this commit:
- Quote shell expansion of RBENV_ROOT (as per suggestion in issue #7 by tobiasoleary)
- Set RBENV_ROOT explicitly to default value if previously unset, to avoid error message and unexpected behavior when RBENV_ROOT is not set.

This makes it easier for folks to copy&paste the suggested shell commands. The fix suggested in issue #7 is important to users with a space in their home directory path, like one may encounter in GUI user environments like Windows and Mac. Additionally, set RBENV_ROOT to its default value if unset, to avoid an error message (or worse, creating a /plugins directory in the fle system root, which will not be picked up by rbenv anyway).

Tested on bash, but the syntax should work on all Bourne shell derived shells, e.g. zsh, sh and dash.
