### PR TITLE
Enable compatibility with fish shell

### DIFF
--- a/bin/rbenv-sh-update
+++ b/bin/rbenv-sh-update
@@ -2,9 +2,7 @@
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x
 
-echo -n "$(which rbenv-update) && "
-echo -n 'echo -e "\033[1;32mreloading rbenv\033[0m" && '
-echo -n 'eval "$(rbenv init -)" && '
-echo -n 'echo -e " \033[1;32m|\033[0m  done"'
-
-echo
+echo "$(which rbenv-update)"
+echo 'echo -e "\033[1;32mreloading rbenv\033[0m"'
+eval "$(rbenv init -)"
+echo 'echo -e " \033[1;32m|\033[0m  done"'


### PR DESCRIPTION
Hello!

I'm using fish shell and noticed that it chokes up on `rbenv-sh-update`, so I went ahead and made the changes necessary to get it working with fish, while maintaining compatibility with bash/zsh. I admit that I kind of just tweaked it until it worked without fully understanding the original intent of the script, so forgive me if I've completely missed the point.

Thanks!
