### PR TITLE
respect repository and branch names

### DIFF
--- a/bin/rbenv-update
+++ b/bin/rbenv-update
@@ -15,9 +15,7 @@ is_git_repo() {
 rbenv_update() {
   echo -e "\033[1;32mupdating $1\033[0m"
   if is_git_repo; then
-    git checkout master 2>&1 | indent_output
-    git fetch origin 2>&1 | indent_output
-    git pull origin master 2>&1 | indent_output
+    git pull 2>&1 | indent_output
   else
     echo -e "Not a git repo; skipping..." | indent_output
   fi


### PR DESCRIPTION
Respect the currently checked out branch, and just pull from the configured remote for the current branch.

Currently rbenv-update is making a lot of assumptions:

1) that you have a branch named `master`
2) that you have a remote named `origin`
3) that `master` is the branch you _want_ to be using
4) that `origin` is the remote you _want_ to be using (this precludes using forks - unless the fork is named `origin`...)

The repository and branch arguments are optional. Doing a simple `git pull` will remain on the currently checked out branch, and will use the configured remote for the current branch. This allows the user to remain in control of branch names, remote names, active branch, and use forks if they so choose.
