### PR TITLE
Only git-pull if an rbenv git repo. fixes #16

### DIFF
--- a/bin/rbenv-update
+++ b/bin/rbenv-update
@@ -9,7 +9,7 @@ indent_output() {
 }
 
 is_git_repo() {
-  $(git rev-parse --git-dir &>/dev/null)
+  $(git remote -v | grep rbenv &>/dev/null)
 }
 
 rbenv_update() {
@@ -17,7 +17,7 @@ rbenv_update() {
   if is_git_repo; then
     git pull 2>&1 | indent_output
   else
-    echo -e "Not a git repo; skipping..." | indent_output
+    echo -e "Not an rbenv git repo; skipping..." | indent_output
   fi
   echo
 }

--- a/bin/rbenv-update
+++ b/bin/rbenv-update
@@ -8,13 +8,13 @@ indent_output() {
   done
 }
 
-is_git_repo() {
+is_rbenv_git_repo() {
   $(git remote -v | grep rbenv &>/dev/null)
 }
 
 rbenv_update() {
   echo -e "\033[1;32mupdating $1\033[0m"
-  if is_git_repo; then
+  if is_rbenv_git_repo; then
     git pull 2>&1 | indent_output
   else
     echo -e "Not an rbenv git repo; skipping..." | indent_output


### PR DESCRIPTION
Uses `git remote -v | grep rbenv` to determine if current directory/plugin is a git repo. This way if none of the remotes match 'rbenv', it is skipped. Specifically for rbenv itself when installed via homebrew; since it's under homebrew's git repo.