### PR TITLE
use rbenv-root command instead of env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@ This [rbenv](http://rbenv.org/) plugin adds the `rbenv update` command that upda
 Simply clone the repository into the plugins directory:
 
     [ -z "$RBENV_ROOT" ] && export RBENV_ROOT="$HOME/.rbenv"
-    mkdir -p "$RBENV_ROOT/plugins"
-    git clone https://github.com/rkh/rbenv-update.git "$RBENV_ROOT/plugins/rbenv-update"
+    mkdir -p "$(rbenv root)/plugins"
+    git clone https://github.com/rkh/rbenv-update.git "$(rbenv root)/plugins/rbenv-update"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,5 @@ This [rbenv](http://rbenv.org/) plugin adds the `rbenv update` command that upda
 
 Simply clone the repository into the plugins directory:
 
-    [ -z "$RBENV_ROOT" ] && export RBENV_ROOT="$HOME/.rbenv"
     mkdir -p "$(rbenv root)/plugins"
     git clone https://github.com/rkh/rbenv-update.git "$(rbenv root)/plugins/rbenv-update"

--- a/bin/rbenv-update
+++ b/bin/rbenv-update
@@ -25,7 +25,7 @@ rbenv_update() {
 cd "$(dirname $(which rbenv))"
 rbenv_update rbenv
 
-cd ${RBENV_ROOT:-$(rbenv root)}
+cd $RBENV_ROOT
 for plugin in plugins/*; do
   pushd $plugin >/dev/null
   rbenv_update `basename $plugin`


### PR DESCRIPTION
rbenv guarantees that $RBENV_ROOT exists within the environment in which an rbenv plugin runs. There is no need to shell out to rbenv-root to get that value (all it does is echo $RBENV_ROOT, anyhow).

 - change the binary to change dir via $RBENV_ROOT exclusively

However, $RBENV_ROOT may not exist when a user is directly installing rbenv-update. So the installation instructions should rely on $(rbenv root) which will provide the default value if $RBENV_ROOT isn't set by the user.

 - update readme install instructions to use $(rbenv root)