### PR TITLE
Ensure git defaults for git-pull

### DIFF
--- a/bin/rbenv-update
+++ b/bin/rbenv-update
@@ -15,7 +15,7 @@ is_rbenv_git_repo() {
 rbenv_update() {
   echo -e "\033[1;32mupdating $1\033[0m"
   if is_rbenv_git_repo; then
-    git pull 2>&1 | indent_output
+    git pull --no-rebase --ff 2>&1 | indent_output
   else
     echo -e "Not an rbenv git repo; skipping..." | indent_output
   fi


### PR DESCRIPTION
git-pull can be configured by the user to do non-default things

merge.ff can be set to false or only (true is default) so pass `--ff` to
reset this setting to default behavior in case it was configured by the
user

pull.rebase can be set to true to cause pulls to do rebases instead of
merges. pass `--no-rebase` to ensure git-pull is invoked with the
default behavior regardless if user has configured pull.rebase to true