### PR TITLE
Update grep to recognize ruby-build

### DIFF
--- a/bin/rbenv-update
+++ b/bin/rbenv-update
@@ -9,7 +9,7 @@ indent_output() {
 }
 
 is_rbenv_git_repo() {
-  $(git remote -v | grep rbenv &>/dev/null)
+  $(git remote -v | grep -E 'rbenv|ruby-build' &>/dev/null)
 }
 
 rbenv_update() {


### PR DESCRIPTION
Add `ruby-build` to the `grep` pattern so that it is recognized as a legitimate `rbenv` plugin.

Addresses issue referenced in #21.