### PR TITLE
Add support for fish shell

### DIFF
--- a/bin/rbenv-sh-update
+++ b/bin/rbenv-sh-update
@@ -2,9 +2,21 @@
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x
 
-echo -n "$(which rbenv-update) && "
-echo -n 'echo -e "\033[1;32mreloading rbenv\033[0m" && '
-echo -n 'eval "$(rbenv init -)" && '
-echo -n 'echo -e " \033[1;32m|\033[0m  done"'
+shell="$(basename "${RBENV_SHELL:-$SHELL}")"
+
+case "$shell" in
+fish )
+  echo -n "$(which rbenv-update); and "
+  echo -n 'echo -e "\033[1;32mreloading rbenv\033[0m"; and '
+  echo -n '. (rbenv init - | psub); and '
+  echo -n 'echo -e " \033[1;32m|\033[0m  done"'
+  ;;
+* )
+  echo -n "$(which rbenv-update) && "
+  echo -n 'echo -e "\033[1;32mreloading rbenv\033[0m" && '
+  echo -n 'eval "$(rbenv init -)" && '
+  echo -n 'echo -e " \033[1;32m|\033[0m  done"'
+  ;;
+esac
 
 echo


### PR DESCRIPTION
This adds support for fish shell to rbenv-sh-update, similar to the way other rbenv-sh-* scripts support fish.