### PR TITLE
Fix RBENV_ROOT problems, conditional colored output, add `--noop`

### DIFF
--- a/bin/rbenv-sh-update
+++ b/bin/rbenv-sh-update
@@ -6,13 +6,13 @@ shell="$(basename "${RBENV_SHELL:-$SHELL}")"
 
 case "$shell" in
 fish )
-  echo -n "$(which rbenv-update); and "
+  echo -n "command rbenv update; and "
   echo -n 'echo -e "\033[1;32mreloading rbenv\033[0m"; and '
   echo -n '. (rbenv init - | psub); and '
   echo -n 'echo -e " \033[1;32m|\033[0m  done"'
   ;;
 * )
-  echo -n "$(which rbenv-update) && "
+  echo -n "command rbenv update && "
   echo -n 'echo -e "\033[1;32mreloading rbenv\033[0m" && '
   echo -n 'eval "$(rbenv init -)" && '
   echo -n 'echo -e " \033[1;32m|\033[0m  done"'

--- a/bin/rbenv-sh-update
+++ b/bin/rbenv-sh-update
@@ -6,13 +6,13 @@ shell="$(basename "${RBENV_SHELL:-$SHELL}")"
 
 case "$shell" in
 fish )
-  echo -n "command rbenv update; and "
+  echo -n "command rbenv update $@; and "
   echo -n 'echo -e "\033[1;32mreloading rbenv\033[0m"; and '
   echo -n '. (rbenv init - | psub); and '
   echo -n 'echo -e " \033[1;32m|\033[0m  done"'
   ;;
 * )
-  echo -n "command rbenv update && "
+  echo -n "command rbenv update $@ && "
   echo -n 'echo -e "\033[1;32mreloading rbenv\033[0m" && '
   echo -n 'eval "$(rbenv init -)" && '
   echo -n 'echo -e " \033[1;32m|\033[0m  done"'

--- a/bin/rbenv-sh-update
+++ b/bin/rbenv-sh-update
@@ -6,17 +6,31 @@ shell="$(basename "${RBENV_SHELL:-$SHELL}")"
 
 case "$shell" in
 fish )
-  echo -n "command rbenv update $@; and "
-  echo -n 'echo -e "\033[1;32mreloading rbenv\033[0m"; and '
-  echo -n '. (rbenv init - | psub); and '
-  echo -n 'echo -e " \033[1;32m|\033[0m  done"'
+  cat <<EOF
+command rbenv update $@
+if fish -c '[ -t 1 ]; or exit 1'
+  printf "\\e[1;32mreloading rbenv\\e[0m\\n"
+  . (rbenv init -|psub)
+  printf " \\033[1;32m|\\033[0m  done\\n"
+else
+  printf "reloading rbenv\\n"
+  . (rbenv init -|psub)
+  printf " |  done\\n"
+end
+EOF
   ;;
 * )
-  echo -n "command rbenv update $@ && "
-  echo -n 'echo -e "\033[1;32mreloading rbenv\033[0m" && '
-  echo -n 'eval "$(rbenv init -)" && '
-  echo -n 'echo -e " \033[1;32m|\033[0m  done"'
+  cat <<EOF
+command rbenv update $@
+if [ -t 1 ]; then
+  printf "\\e[1;32mreloading rbenv\\e[0m\\n"
+  eval "\$(rbenv init -)"
+  printf " \\033[1;32m|\\033[0m  done\\n"
+else
+  printf "reloading rbenv\\n"
+  eval "\$(rbenv init -)"
+  printf " |  done\\n"
+fi
+EOF
   ;;
 esac
-
-echo

--- a/bin/rbenv-sh-update
+++ b/bin/rbenv-sh-update
@@ -8,7 +8,7 @@ case "$shell" in
 fish )
   cat <<EOF
 command rbenv update $@
-if fish -c '[ -t 1 ]; or exit 1'
+if command test -t 1
   printf "\\e[1;32mreloading rbenv\\e[0m\\n"
   . (rbenv init -|psub)
   printf " \\033[1;32m|\\033[0m  done\\n"

--- a/bin/rbenv-update
+++ b/bin/rbenv-update
@@ -25,8 +25,7 @@ rbenv_update() {
 cd "$(dirname $(which rbenv))"
 rbenv_update rbenv
 
-cd "${RBENV_ROOT:-$(rbenv root)}"
-for plugin in plugins/*; do
+for plugin in "$RBENV_ROOT"/plugins/*; do
   pushd $plugin >/dev/null
   rbenv_update `basename $plugin`
   popd >/dev/null

--- a/bin/rbenv-update
+++ b/bin/rbenv-update
@@ -9,7 +9,7 @@ indent_output() {
 }
 
 is_rbenv_git_repo() {
-  $(git remote -v | grep -E 'rbenv|ruby-build' &>/dev/null)
+  git remote -v 2>/dev/null | grep -q 'rbenv\|ruby-build'
 }
 
 rbenv_update() {

--- a/bin/rbenv-update
+++ b/bin/rbenv-update
@@ -1,6 +1,22 @@
 #!/usr/bin/env bash
+# Usage: rbenv update [--noop]
+# Summary: Updates to latest version of rbenv and plugins from git.
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x
+
+noop=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+  --noop ) noop=true ;;
+  esac
+  shift 1
+done
+
+git() {
+  local cmd="command"
+  [[ -n "$noop" && "$1" = "pull" ]] && cmd="echo"
+  $cmd git "$@"
+}
 
 if [ -t 1 ]; then
   color="\e[1;32m"

--- a/bin/rbenv-update
+++ b/bin/rbenv-update
@@ -49,8 +49,10 @@ rbenv_update() {
 cd "$(dirname $(which rbenv))"
 rbenv_update rbenv
 
+shopt -s nullglob
 for plugin in "$RBENV_ROOT"/plugins/*; do
   pushd $plugin >/dev/null
   rbenv_update `basename $plugin`
   popd >/dev/null
 done
+shopt -u nullglob

--- a/bin/rbenv-update
+++ b/bin/rbenv-update
@@ -2,9 +2,17 @@
 set -e
 [ -n "$RBENV_DEBUG" ] && set -x
 
+if [ -t 1 ]; then
+  color="\e[1;32m"
+  reset="\e[0m"
+else
+  color=""
+  reset=""
+fi
+
 indent_output() {
   while read data; do
-    echo -e " \033[1;32m|\033[0m  $data"
+    printf " ${color}|${reset}  %s\n" "$data"
   done
 }
 
@@ -13,11 +21,11 @@ is_rbenv_git_repo() {
 }
 
 rbenv_update() {
-  echo -e "\033[1;32mupdating $1\033[0m"
+  printf "${color}updating %s${reset}\n" "$1"
   if is_rbenv_git_repo; then
     git pull --no-rebase --ff 2>&1 | indent_output
   else
-    echo -e "Not an rbenv git repo; skipping..." | indent_output
+    echo "Not an rbenv git repo; skipping..." | indent_output
   fi
   echo
 }


### PR DESCRIPTION
Many fixes, single PR because the changes are inter-dependent on each other and I couldn't be bothered:

* Fixed invocation from `sh-update` so that RBENV_ROOT is guaranteed to be present.
* Don't output ANSI color sequences if stdout is not a terminal. This is being a good unix citizen.
* Add `--noop` flag to avoid actually `git pull`ing and just show what would be done

Fixes #21, closes #25