### PR TITLE
Move most output from rbenv-sh-update into rbenv-update proper

### DIFF
--- a/bin/rbenv-sh-update
+++ b/bin/rbenv-sh-update
@@ -8,29 +8,22 @@ case "$shell" in
 fish )
   cat <<EOF
 command rbenv update $@
+source (rbenv init -|psub)
 if isatty stdout
-  echo (set_color --bold)"reloading rbenv"(set_color normal)
-  source (rbenv init -|psub)
-  echo (set_color --bold)" |  "(set_color normal)"done"
-else
-  echo "reloading rbenv"
-  source (rbenv init -|psub)
-  echo " |  done"
+  set_color --bold
 end
+echo "Done updating rbenv"
+set_color normal
 EOF
   ;;
 * )
   cat <<EOF
 command rbenv update $@;
+eval "\$(rbenv init -)";
 if [ -t 1 ]; then
-  printf "\\e[1;32mreloading rbenv\\e[0m\\n";
-  eval "\$(rbenv init -)";
-  printf " \\033[1;32m|\\033[0m  done\\n";
-else
-  printf "reloading rbenv\\n";
-  eval "\$(rbenv init -)";
-  printf " |  done\\n";
+  printf "\\e[1;32m";
 fi
+printf "Done updating rbenv\\e[0m\\n";
 EOF
   ;;
 esac

--- a/bin/rbenv-sh-update
+++ b/bin/rbenv-sh-update
@@ -8,14 +8,14 @@ case "$shell" in
 fish )
   cat <<EOF
 command rbenv update $@
-if command test -t 1
-  printf "\\e[1;32mreloading rbenv\\e[0m\\n"
-  . (rbenv init -|psub)
-  printf " \\033[1;32m|\\033[0m  done\\n"
+if isatty stdout
+  echo (set_color --bold)"reloading rbenv"(set_color normal)
+  source (rbenv init -|psub)
+  echo (set_color --bold)" |  "(set_color normal)"done"
 else
-  printf "reloading rbenv\\n"
-  . (rbenv init -|psub)
-  printf " |  done\\n"
+  echo "reloading rbenv"
+  source (rbenv init -|psub)
+  echo " |  done"
 end
 EOF
   ;;

--- a/bin/rbenv-update
+++ b/bin/rbenv-update
@@ -56,3 +56,4 @@ for plugin in "$RBENV_ROOT"/plugins/*; do
   popd >/dev/null
 done
 shopt -u nullglob
+print_colored "Reloading rbenv"


### PR DESCRIPTION
These are the two commits moved from #28 that moves most of the output into `rbenv-update` to make it accept the `--quiet`/`--verbose` flag.