### PR TITLE
sh-update should respect --quiet/--noop flags

### DIFF
--- a/bin/rbenv-sh-update
+++ b/bin/rbenv-sh-update
@@ -5,8 +5,8 @@ set -e
 shell="$(basename "${RBENV_SHELL:-$SHELL}")"
 
 # Parse command line flags
-if echo "$@" | egrep -q "(-n|--noop)"; then noop=true; fi
-if echo "$@" | egrep -q "(-q|--quiet|--silent)"; then quiet=true; fi
+if echo "$@" | egrep -q '(-n\|--noop)'; then noop=true; fi
+if echo "$@" | egrep -q '(-q\|--quiet\|--silent)'; then quiet=true; fi
 
 colorize() {
   if [ "$shell" = fish ]; then echo "  if isatty stdout; set_color --bold; end"

--- a/bin/rbenv-sh-update
+++ b/bin/rbenv-sh-update
@@ -4,11 +4,13 @@ set -e
 
 shell="$(basename "${RBENV_SHELL:-$SHELL}")"
 
+
+echo "command rbenv update $@;"
+echo "if command test -t 1; then"
+
 case "$shell" in
 fish )
   cat <<EOF
-command rbenv update $@
-if command test -t 1
   printf "\\e[1;32mreloading rbenv\\e[0m\\n"
   . (rbenv init -|psub)
   printf " \\033[1;32m|\\033[0m  done\\n"
@@ -21,8 +23,6 @@ EOF
   ;;
 * )
   cat <<EOF
-command rbenv update $@;
-if [ -t 1 ]; then
   printf "\\e[1;32mreloading rbenv\\e[0m\\n";
   eval "\$(rbenv init -)";
   printf " \\033[1;32m|\\033[0m  done\\n";

--- a/bin/rbenv-sh-update
+++ b/bin/rbenv-sh-update
@@ -11,30 +11,23 @@ case "$1" in
 esac
 
 
-
-echo "if command rbenv update $@; then"
-
-if [ -z "$quiet" ]; then
-  echo "  if command test -t 1; then"
-  echo "    printf \"\\e[1;32mReloading rbenv\\e[0m\\n\";"
-  echo "  else"
-  echo "    printf \"Reloading rbenv\\n\";"
-  echo "  fi;"
-fi
-
-if [ -z "$noop" ]; then
-  case "$shell" in
-  fish ) echo "  . (rbenv init -|psub)" ;;
-  *    ) echo "  eval \"\$(rbenv init -)\";" ;;
-  esac
-fi
-
-if [ -z "$quiet" ]; then
-  echo "  if command test -t 1; then"
-  echo "    printf \" \\033[1;32m|\\033[0m  done\\n\";"
-  echo "  else"
-  echo "    printf \" |  done\\n\";"
-  echo "  fi;"
-fi
-
-echo "fi;"
+case "$shell" in
+  fish )
+    echo "  . (rbenv init -|psub)"
+    ;;
+  * )
+    echo "if command rbenv update $@; then"
+    if [ -z "$quiet" ]; then
+      echo "  if [ -t 1 ]; then printf \"\\e[1;32mReloading rbenv\\e[0m\\n\";"
+      echo "  else printf \"Reloading rbenv\\n\"; fi;"
+    fi
+    if [ -z "$noop" ]; then
+      echo "  eval \"\$(rbenv init -)\";"
+    fi
+    if [ -z "$quiet" ]; then
+      echo "  if [ -t 1 ]; then printf \" \\033[1;32m|\\033[0m  done\\n\";"
+      echo "  else printf \" |  done\\n\"; fi;"
+    fi
+    echo "fi;"
+    ;;
+esac

--- a/bin/rbenv-sh-update
+++ b/bin/rbenv-sh-update
@@ -7,7 +7,6 @@ shell="$(basename "${RBENV_SHELL:-$SHELL}")"
 # Parse command line flags
 case "$1" in
   -n | --noop ) noop=true ;;
-  -v | --verbose ) verbose=true ;;
   -q | --quiet | --silent ) quiet=true ;;
 esac
 

--- a/bin/rbenv-sh-update
+++ b/bin/rbenv-sh-update
@@ -12,27 +12,29 @@ esac
 
 
 
-echo "command rbenv update $@;"
+echo "if command rbenv update $@; then"
 
 if [ -z "$quiet" ]; then
-  echo "if command test -t 1; then"
-  echo "  printf \"\\e[1;32mReloading rbenv\\e[0m\\n\";"
-  echo "else"
-  echo "  printf \"Reloading rbenv\\n\";"
-  echo "fi;"
+  echo "  if command test -t 1; then"
+  echo "    printf \"\\e[1;32mReloading rbenv\\e[0m\\n\";"
+  echo "  else"
+  echo "    printf \"Reloading rbenv\\n\";"
+  echo "  fi;"
 fi
 
 if [ -z "$noop" ]; then
   case "$shell" in
-  fish ) echo ". (rbenv init -|psub)" ;;
-  *    ) echo "eval \"\$(rbenv init -)\";" ;;
+  fish ) echo "  . (rbenv init -|psub)" ;;
+  *    ) echo "  eval \"\$(rbenv init -)\";" ;;
   esac
 fi
 
 if [ -z "$quiet" ]; then
-  echo "if command test -t 1; then"
-  echo "  printf \" \\033[1;32m|\\033[0m  done\\n\";"
-  echo "else"
-  echo "  printf \" |  done\\n\";"
-  echo "fi;"
+  echo "  if command test -t 1; then"
+  echo "    printf \" \\033[1;32m|\\033[0m  done\\n\";"
+  echo "  else"
+  echo "    printf \" |  done\\n\";"
+  echo "  fi;"
 fi
+
+echo "fi;"

--- a/bin/rbenv-sh-update
+++ b/bin/rbenv-sh-update
@@ -4,15 +4,24 @@ set -e
 
 shell="$(basename "${RBENV_SHELL:-$SHELL}")"
 
+# Parse command line flags
+case "$1" in
+  -n | --noop ) noop=true ;;
+  -v | --verbose ) verbose=true ;;
+  -q | --quiet | --silent ) quiet=true ;;
+esac
+
+
 
 echo "command rbenv update $@;"
 
-
-echo "if command test -t 1; then"
-echo "  printf \"\\e[1;32mReloading rbenv\\e[0m\\n\";"
-echo "else"
-echo "  printf \"reloading rbenv\\n\";"
-echo "fi;"
+if [ -z "$quiet" ]; then
+  echo "if command test -t 1; then"
+  echo "  printf \"\\e[1;32mReloading rbenv\\e[0m\\n\";"
+  echo "else"
+  echo "  printf \"Reloading rbenv\\n\";"
+  echo "fi;"
+fi
 
 case "$shell" in
 fish ) echo ". (rbenv init -|psub)" ;;

--- a/bin/rbenv-sh-update
+++ b/bin/rbenv-sh-update
@@ -8,41 +8,29 @@ shell="$(basename "${RBENV_SHELL:-$SHELL}")"
 if echo "$@" | egrep -q "(-n|--noop)"; then noop=true; fi
 if echo "$@" | egrep -q "(-q|--quiet|--silent)"; then quiet=true; fi
 
+colorize() {
+  if [ "$shell" = fish ]; then echo "  if isatty stdout; set_color --bold; end"
+  else echo "  if [ -t 1 ]; then printf \"\\e[1;32m\"; fi;"; fi
+
+  echo "  printf \"$1\";"
+
+  if [ "$shell" = fish ]; then echo "  set_color normal"
+  else echo "  if [ -t 1 ]; then printf \"\\e[0m\"; fi;"; fi
+
+  echo "  printf \"$2\";"
+}
+
 case "$shell" in
   fish )
     echo "if command rbenv update $@"
-    if [ -z "$quiet" ]; then
-      echo "  if isatty stdout"
-      echo "    set_color --bold"
-      echo "  end"
-      echo '  echo "Reloading rbenv"'
-      echo "  set_color normal"
-    fi
-    if [ -z "$noop" ]; then
-      echo "  source (rbenv init -|psub)"
-    fi
-    if [ -z "$quiet" ]; then
-      echo "  if isatty stdout"
-      echo "    set_color --bold"
-      echo "  end"
-      echo '  echo " |  done"'
-      echo "  set_color normal"
-    fi
-    echo "end"
-    ;;
+      if [ -z "$quiet" ]; then colorize "Reloading rbenv\n"; fi
+      if [ -z "$noop" ];  then echo "  source (rbenv init -|psub)"; fi
+      if [ -z "$quiet" ]; then colorize " | " "done\n"; fi
+    echo "end" ;;
   * )
     echo "if command rbenv update $@; then"
-    if [ -z "$quiet" ]; then
-      echo "  if [ -t 1 ]; then printf \"\\e[1;32mReloading rbenv\\e[0m\\n\";"
-      echo "  else printf \"Reloading rbenv\\n\"; fi;"
-    fi
-    if [ -z "$noop" ]; then
-      echo "  eval \"\$(rbenv init -)\";"
-    fi
-    if [ -z "$quiet" ]; then
-      echo "  if [ -t 1 ]; then printf \" \\033[1;32m|\\033[0m  done\\n\";"
-      echo "  else printf \" |  done\\n\"; fi;"
-    fi
-    echo "fi;"
-    ;;
+      if [ -z "$quiet" ]; then colorize "Reloading rbenv\n"; fi
+      if [ -z "$noop" ];  then echo "  eval \"\$(rbenv init -)\";"; fi
+      if [ -z "$quiet" ]; then colorize " | " "done\n"; fi
+    echo "fi;" ;;
 esac

--- a/bin/rbenv-sh-update
+++ b/bin/rbenv-sh-update
@@ -12,15 +12,21 @@ case "$shell" in
   fish )
     echo "if command rbenv update $@"
     if [ -z "$quiet" ]; then
-      echo "  if isatty stdout; printf \"\\e[1;32mReloading rbenv\\e[0m\\n\""
-      echo "  else printf \"Reloading rbenv\\n\"; end"
+      echo "  if isatty stdout"
+      echo "    set_color --bold"
+      echo "  end"
+      echo '  echo "Reloading rbenv"'
+      echo "  set_color normal"
     fi
     if [ -z "$noop" ]; then
       echo "  source (rbenv init -|psub)"
     fi
     if [ -z "$quiet" ]; then
-      echo "  if isatty stdout; printf \" \\033[1;32m|\\033[0m  done\\n\""
-      echo "  else printf \" |  done\\n\"; end"
+      echo "  if isatty stdout"
+      echo "    set_color --bold"
+      echo "  end"
+      echo '  echo " |  done"'
+      echo "  set_color normal"
     fi
     echo "end"
     ;;

--- a/bin/rbenv-sh-update
+++ b/bin/rbenv-sh-update
@@ -13,7 +13,19 @@ esac
 
 case "$shell" in
   fish )
-    echo "  . (rbenv init -|psub)"
+    echo "if command rbenv update $@"
+    if [ -z "$quiet" ]; then
+      echo "  if isatty stdout; printf \"\\e[1;32mReloading rbenv\\e[0m\\n\""
+      echo "  else printf \"Reloading rbenv\\n\"; end"
+    fi
+    if [ -z "$noop" ]; then
+      echo "  source (rbenv init -|psub)"
+    fi
+    if [ -z "$quiet" ]; then
+      echo "  if isatty stdout; printf \" \\033[1;32m|\\033[0m  done\\n\""
+      echo "  else printf \" |  done\\n\"; end"
+    fi
+    echo "end"
     ;;
   * )
     echo "if command rbenv update $@; then"

--- a/bin/rbenv-sh-update
+++ b/bin/rbenv-sh-update
@@ -28,3 +28,11 @@ if [ -z "$noop" ]; then
   *    ) echo "eval \"\$(rbenv init -)\";" ;;
   esac
 fi
+
+if [ -z "$quiet" ]; then
+  echo "if command test -t 1; then"
+  echo "  printf \" \\033[1;32m|\\033[0m  done\\n\";"
+  echo "else"
+  echo "  printf \" |  done\\n\";"
+  echo "fi;"
+fi

--- a/bin/rbenv-sh-update
+++ b/bin/rbenv-sh-update
@@ -23,7 +23,9 @@ if [ -z "$quiet" ]; then
   echo "fi;"
 fi
 
-case "$shell" in
-fish ) echo ". (rbenv init -|psub)" ;;
-*    ) echo "eval \"\$(rbenv init -)\";" ;;
-esac
+if [ -z "$noop" ]; then
+  case "$shell" in
+  fish ) echo ". (rbenv init -|psub)" ;;
+  *    ) echo "eval \"\$(rbenv init -)\";" ;;
+  esac
+fi

--- a/bin/rbenv-sh-update
+++ b/bin/rbenv-sh-update
@@ -7,11 +7,11 @@ shell="$(basename "${RBENV_SHELL:-$SHELL}")"
 
 echo "command rbenv update $@;"
 echo "if command test -t 1; then"
+echo "printf \"\\e[1;32mReloading rbenv\\e[0m\\n\";"
 
 case "$shell" in
 fish )
   cat <<EOF
-  printf "\\e[1;32mreloading rbenv\\e[0m\\n"
   . (rbenv init -|psub)
   printf " \\033[1;32m|\\033[0m  done\\n"
 else
@@ -23,7 +23,6 @@ EOF
   ;;
 * )
   cat <<EOF
-  printf "\\e[1;32mreloading rbenv\\e[0m\\n";
   eval "\$(rbenv init -)";
   printf " \\033[1;32m|\\033[0m  done\\n";
 else

--- a/bin/rbenv-sh-update
+++ b/bin/rbenv-sh-update
@@ -6,30 +6,15 @@ shell="$(basename "${RBENV_SHELL:-$SHELL}")"
 
 
 echo "command rbenv update $@;"
+
+
 echo "if command test -t 1; then"
-echo "printf \"\\e[1;32mReloading rbenv\\e[0m\\n\";"
+echo "  printf \"\\e[1;32mReloading rbenv\\e[0m\\n\";"
+echo "else"
+echo "  printf \"reloading rbenv\\n\";"
+echo "fi;"
 
 case "$shell" in
-fish )
-  cat <<EOF
-  . (rbenv init -|psub)
-  printf " \\033[1;32m|\\033[0m  done\\n"
-else
-  printf "reloading rbenv\\n"
-  . (rbenv init -|psub)
-  printf " |  done\\n"
-end
-EOF
-  ;;
-* )
-  cat <<EOF
-  eval "\$(rbenv init -)";
-  printf " \\033[1;32m|\\033[0m  done\\n";
-else
-  printf "reloading rbenv\\n";
-  eval "\$(rbenv init -)";
-  printf " |  done\\n";
-fi
-EOF
-  ;;
+fish ) echo ". (rbenv init -|psub)" ;;
+*    ) echo "eval \"\$(rbenv init -)\";" ;;
 esac

--- a/bin/rbenv-sh-update
+++ b/bin/rbenv-sh-update
@@ -5,11 +5,8 @@ set -e
 shell="$(basename "${RBENV_SHELL:-$SHELL}")"
 
 # Parse command line flags
-case "$1" in
-  -n | --noop ) noop=true ;;
-  -q | --quiet | --silent ) quiet=true ;;
-esac
-
+if echo "$@" | egrep -q "(-n|--noop)"; then noop=true; fi
+if echo "$@" | egrep -q "(-q|--quiet|--silent)"; then quiet=true; fi
 
 case "$shell" in
   fish )

--- a/bin/rbenv-update
+++ b/bin/rbenv-update
@@ -23,7 +23,7 @@ while [ $# -gt 0 ]; do
     rbenv-help update
     exit ;;
   * )
-    echo "Unrecognized option: $1" >&2
+    printf "Unrecognized option: $1\n\n" >&2
     rbenv-help update
     exit 1 ;;
   esac


### PR DESCRIPTION
This is a fairly significant change to the sh-update script. However, I believe it has a few benefits.

As much as possible is shared between fish/bash, to minimize code branches. It's not optimal fish, nor optimal bash, but it simplifies the code.

- --quiet (and -q, --silent variants) will mute the 'reloading' and 'done' messages.
- tty detection is unified between fish/bash, as is the color code printing
- --noop now will cause the rbenv re-init to be skipped
- the exit code from rbenv-update is now respected, so a failure exit will prevent the rbenv reload (presently, it should exit as failure if an unrecognized option is given). I would have preferred to use a guard and return/exit if failed (instead of wrapping the entire thing in an `if`) but i'm not confident in how the output of rbenv-sh-update is evaluated to know if that's safe. pinging @mislav for input :)

Some annoyances with this:

- The options parsing is partially duplicated between update and sh-update; although sh-update is only concerned with --quiet and --noop. I don't know of a clean way to fix this duplication.
- Options parsing in sh-update is brittle. It only checks $1 (so the --noop + --quiet case is weird). We can't shift through all the options because we still need to pass them to `update`. If someone wants to take a stab at cleaning up the options parsing (looping without shifting, or shifting while still emitting proper flags to `update`) that would be welcome. looking at you @maxnordlund 